### PR TITLE
Add passthrough of `cborld` `appContextMap`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # vpqr Changelog
 
+## 4.1.0 - 2023-xx-xx
+
+### Added
+- Add passthrough of `cborld` `appContextMap` option.
+
 ## 4.0.0 - 2023-11-29
 
 ### Added

--- a/lib/util.js
+++ b/lib/util.js
@@ -14,7 +14,8 @@ import base32Encode from 'base32-encode';
 const BASE_32_UPPERCASE_MULTIBASE_PREFIX = 'B';
 
 export async function toQrCode({
-  header, jsonldDocument, cborldBytes, documentLoader, size, diagnose
+  header, jsonldDocument, cborldBytes, documentLoader, appContextMap, size,
+  diagnose
 } = {}) {
   if(jsonldDocument && cborldBytes) {
     throw new Error(
@@ -25,6 +26,7 @@ export async function toQrCode({
     cborldBytes = await cborld.encode({
       jsonldDocument,
       documentLoader,
+      appContextMap,
       // to debug, set diagnose: console.log
       diagnose
     });
@@ -49,7 +51,8 @@ export async function toQrCode({
 }
 
 export async function fromQrCode({
-  expectedHeader = '', text, decodeCborld = true, documentLoader, diagnose
+  expectedHeader = '', text, decodeCborld = true, documentLoader,
+  appContextMap, diagnose
 } = {}) {
   if(!(text && text.startsWith(expectedHeader))) {
     throw TypeError('Unsupported QR format.');
@@ -70,6 +73,7 @@ export async function fromQrCode({
   const jsonldDocument = await cborld.decode({
     cborldBytes,
     documentLoader,
+    appContextMap,
     // to debug, set diagnose: console.log
     diagnose
   });

--- a/lib/vpqr.js
+++ b/lib/vpqr.js
@@ -6,17 +6,23 @@ import * as util from './util.js';
 const VP_QR_VERSION = 'VP1';
 const HEADER = VP_QR_VERSION + '-';
 
-export async function toQrCode({vp, documentLoader, size, diagnose} = {}) {
-  return util.toQrCode(
-    {header: HEADER, jsonldDocument: vp, documentLoader, size, diagnose});
+export async function toQrCode({
+  vp, documentLoader, appContextMap, size, diagnose
+} = {}) {
+  return util.toQrCode({
+    header: HEADER, jsonldDocument: vp, documentLoader, appContextMap, size,
+    diagnose
+  });
 }
 
-export async function fromQrCode({text, documentLoader, diagnose} = {}) {
+export async function fromQrCode({
+  text, documentLoader, appContextMap, diagnose
+} = {}) {
   const expectedHeader = HEADER;
   if(!(text && text.startsWith(expectedHeader))) {
     throw TypeError('Unsupported VP QR format.');
   }
   const {jsonldDocument} = await util.fromQrCode(
-    {expectedHeader, text, documentLoader, diagnose});
+    {expectedHeader, text, documentLoader, appContextMap, diagnose});
   return {vp: jsonldDocument};
 }


### PR DESCRIPTION
Only the encode call has been tested.